### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server that provides image generation capabilities using Google's Gemini 2 API.
 
+<a href="https://glama.ai/mcp/servers/@sanxfxteam/gemini-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sanxfxteam/gemini-mcp-server/badge" alt="Gemini Image Generation Server MCP server" />
+</a>
+
 ## Setup
 
 1. Install dependencies:
@@ -55,4 +59,4 @@ Example MCP request:
 
 - This server uses the experimental image generation feature of Gemini 2
 - Make sure you have appropriate access and API keys from Google
-- The server communicates using the Model Context Protocol over stdio 
+- The server communicates using the Model Context Protocol over stdio


### PR DESCRIPTION
This PR adds a badge for the [Gemini MCP Image Generation Server](https://glama.ai/mcp/servers/@sanxfxteam/gemini-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sanxfxteam/gemini-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sanxfxteam/gemini-mcp-server/badge" alt="Gemini Image Generation Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.